### PR TITLE
Token saving

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -16,14 +16,14 @@ using System.Linq;
 
 public class MyBot : IChessBot
 {
-    // Pawn, Knight, Bishop, Rook, Queen, King
+    // Pawn, Knight, Bishop, Rook, Queen, King 
     private static readonly int[] PieceValues = { 77, 302, 310, 434, 890, 0, // Middlegame
                                                  109, 331, 335, 594, 1116, 0, }, // Endgame
                                   MoveScores = new int[218],
 
     // Big table packed with data from premade piece square tables
     // Access using using PackedEvaluationTables[square * 12 + pieceType] = score
-    UnpackedPestoTables =
+    UnpackedPestoTables = 
         new[] {
             59445390105436474986072674560m, 70290677894333901267150682880m, 71539517137735599738519086336m, 78957476706409475571971323392m, 76477941479143404670656189696m, 78020492916263816717520067072m, 77059410983631195892660944640m, 61307098105356489251813834752m,
             77373759864583735626648317994m, 3437103645554060776222818613m, 5013542988189698109836108074m, 2865258213628105516468149820m, 5661498819074815745865228343m, 8414185094009835055136457260m, 7780689186187929908113377023m, 2486769613674807657298071274m,
@@ -35,7 +35,7 @@ public class MyBot : IChessBot
             64062225663112462441888793856m, 67159522168020586196575185664m, 71185268483909686702087266048m, 75814236297773358797609495296m, 69944882517184684696171572480m, 74895414840161820695659345152m, 69305332238573146615004392448m, 63422661310571918454614119936m,
         }.SelectMany(packedTable =>
         new System.Numerics.BigInteger(packedTable).ToByteArray().Take(12)
-                    // Using search max time since it's an integer than initializes to zero and is assgined before being used again
+                    // Using search max time since it's an integer than initializes to zero and is assgined before being used again 
                     .Select((square, index) => (int)((sbyte)square * 1.461) + PieceValues[index % 12])
                 .ToArray()
         ).ToArray();
@@ -76,9 +76,9 @@ public class MyBot : IChessBot
             // Progressively increase search depth, starting from 2
             depth = 2, alpha = -999999, beta = 999999, eval;
 
-        for (; ; )
+        for (;;)
         {
-            eval = PVS(depth++, alpha, beta, 0, true);
+            eval = PVS(depth, alpha, beta, 0, true);
 
             // Out of time -> soft bound exceeded
             if (timer.MillisecondsElapsedThisTurn > searchMaxTime / 3)
@@ -101,7 +101,7 @@ public class MyBot : IChessBot
                 }
 
                 Console.WriteLine("Info: depth: {0, 2} || eval: {1, 6} || nodes: {2, 9} || nps: {3, 8} || time: {4, 5}ms || best move: {5}{6}",
-                    depth - 1,
+                    depth,
                     evalWithMate,
                     nodes,
                     1000 * nodes / (timer.MillisecondsElapsedThisTurn + 1),
@@ -113,6 +113,7 @@ public class MyBot : IChessBot
                 // Set up window for next search
                 alpha = eval - 17;
                 beta = eval + 17;
+                depth++;
             }
         }
 

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -16,14 +16,14 @@ using System.Linq;
 
 public class MyBot : IChessBot
 {
-    // Pawn, Knight, Bishop, Rook, Queen, King 
+    // Pawn, Knight, Bishop, Rook, Queen, King
     private static readonly int[] PieceValues = { 77, 302, 310, 434, 890, 0, // Middlegame
                                                  109, 331, 335, 594, 1116, 0, }, // Endgame
                                   MoveScores = new int[218],
 
     // Big table packed with data from premade piece square tables
     // Access using using PackedEvaluationTables[square * 12 + pieceType] = score
-    UnpackedPestoTables = 
+    UnpackedPestoTables =
         new[] {
             59445390105436474986072674560m, 70290677894333901267150682880m, 71539517137735599738519086336m, 78957476706409475571971323392m, 76477941479143404670656189696m, 78020492916263816717520067072m, 77059410983631195892660944640m, 61307098105356489251813834752m,
             77373759864583735626648317994m, 3437103645554060776222818613m, 5013542988189698109836108074m, 2865258213628105516468149820m, 5661498819074815745865228343m, 8414185094009835055136457260m, 7780689186187929908113377023m, 2486769613674807657298071274m,
@@ -35,7 +35,7 @@ public class MyBot : IChessBot
             64062225663112462441888793856m, 67159522168020586196575185664m, 71185268483909686702087266048m, 75814236297773358797609495296m, 69944882517184684696171572480m, 74895414840161820695659345152m, 69305332238573146615004392448m, 63422661310571918454614119936m,
         }.SelectMany(packedTable =>
         new System.Numerics.BigInteger(packedTable).ToByteArray().Take(12)
-                    // Using search max time since it's an integer than initializes to zero and is assgined before being used again 
+                    // Using search max time since it's an integer than initializes to zero and is assgined before being used again
                     .Select((square, index) => (int)((sbyte)square * 1.461) + PieceValues[index % 12])
                 .ToArray()
         ).ToArray();
@@ -76,9 +76,9 @@ public class MyBot : IChessBot
             // Progressively increase search depth, starting from 2
             depth = 2, alpha = -999999, beta = 999999, eval;
 
-        for (;;)
+        for (; ; )
         {
-            eval = PVS(depth, alpha, beta, 0, true);
+            eval = PVS(depth++, alpha, beta, 0, true);
 
             // Out of time -> soft bound exceeded
             if (timer.MillisecondsElapsedThisTurn > searchMaxTime / 3)
@@ -101,7 +101,7 @@ public class MyBot : IChessBot
                 }
 
                 Console.WriteLine("Info: depth: {0, 2} || eval: {1, 6} || nodes: {2, 9} || nps: {3, 8} || time: {4, 5}ms || best move: {5}{6}",
-                    depth,
+                    depth - 1,
                     evalWithMate,
                     nodes,
                     1000 * nodes / (timer.MillisecondsElapsedThisTurn + 1),
@@ -113,7 +113,6 @@ public class MyBot : IChessBot
                 // Set up window for next search
                 alpha = eval - 17;
                 beta = eval + 17;
-                depth++;
             }
         }
 

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -126,11 +126,11 @@ public class MyBot : IChessBot
             // Declare some reused variables
             bool inCheck = board.IsInCheck(),
                 canFPrune = false,
-                isRoot = plyFromRoot++ == 0,
+                isNotRoot = plyFromRoot++ != 0,
                 notPV = beta - alpha == 1;
 
             // Draw detection
-            if (!isRoot && board.IsRepeatedPosition())
+            if (isNotRoot && board.IsRepeatedPosition())
                 return 0;
 
             ulong zobristKey = board.ZobristKey;
@@ -157,7 +157,7 @@ public class MyBot : IChessBot
 
             // Transposition table lookup -> Found a valid entry for this position
             // Avoid retrieving mate scores from the TT since they aren't accurate to the ply
-            if (entryKey == zobristKey && !isRoot && entryDepth >= depth && Math.Abs(entryScore) < 50000 && (
+            if (entryKey == zobristKey && isNotRoot && entryDepth >= depth && Math.Abs(entryScore) < 50000 && (
                     // Exact
                     entryFlag == 1 ||
                     // Upperbound
@@ -296,7 +296,7 @@ public class MyBot : IChessBot
                         newTTFlag = 1;
 
                         // Update the root move
-                        if (isRoot)
+                        if (!isNotRoot)
                             rootMove = move;
                     }
 

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -74,11 +74,11 @@ public class MyBot : IChessBot
         // 1/13th of our remaining time, split among all of the moves
         int searchMaxTime = timer.MillisecondsRemaining / 13,
             // Progressively increase search depth, starting from 2
-            depth = 2, alpha = -999999, beta = 999999, eval;
+            thinkDepth = 2, alpha = -999999, beta = 999999, eval;
 
         for (; ; )
         {
-            eval = PVS(depth++, alpha, beta, 0, true);
+            eval = PVS(thinkDepth++, alpha, beta, 0, true);
 
             // Out of time -> soft bound exceeded
             if (timer.MillisecondsElapsedThisTurn > searchMaxTime / 3)
@@ -101,7 +101,7 @@ public class MyBot : IChessBot
                 }
 
                 Console.WriteLine("Info: depth: {0, 2} || eval: {1, 6} || nodes: {2, 9} || nps: {3, 8} || time: {4, 5}ms || best move: {5}{6}",
-                    depth - 1,
+                    thinkDepth - 1,
                     evalWithMate,
                     nodes,
                     1000 * nodes / (timer.MillisecondsElapsedThisTurn + 1),

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -74,11 +74,11 @@ public class MyBot : IChessBot
         // 1/13th of our remaining time, split among all of the moves
         int searchMaxTime = timer.MillisecondsRemaining / 13,
             // Progressively increase search depth, starting from 2
-            thinkDepth = 2, alpha = -999999, beta = 999999, eval;
+            depth = 2, alpha = -999999, beta = 999999, eval;
 
         for (; ; )
         {
-            eval = PVS(thinkDepth++, alpha, beta, 0, true);
+            eval = PVS(depth++, alpha, beta, 0, true);
 
             // Out of time -> soft bound exceeded
             if (timer.MillisecondsElapsedThisTurn > searchMaxTime / 3)
@@ -101,7 +101,7 @@ public class MyBot : IChessBot
                 }
 
                 Console.WriteLine("Info: depth: {0, 2} || eval: {1, 6} || nodes: {2, 9} || nps: {3, 8} || time: {4, 5}ms || best move: {5}{6}",
-                    thinkDepth - 1,
+                    depth - 1,
                     evalWithMate,
                     nodes,
                     1000 * nodes / (timer.MillisecondsElapsedThisTurn + 1),


### PR DESCRIPTION
Reduce 1 token due to the common usage of `!isRoot` over `isRoot`, which allows you to create `isNotRoot` and spend the `!` there